### PR TITLE
Update GitHub Pages deploayment

### DIFF
--- a/gameci-3_linux.md
+++ b/gameci-3_linux.md
@@ -208,7 +208,7 @@ Also note that we use `fastlane/metadata/android/en-US/changelogs/default.txt` t
           WEBGL_PAGES_PATH: ${{ format('{0}/docs', github.workspace) }}
         run: cp -r $WEBGL_BUILD_PATH $WEBGL_PAGES_PATH;
       - name: Deploy to GitHub Pages
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: main
           file_pattern: docs/**

--- a/gameci-3_linux.md
+++ b/gameci-3_linux.md
@@ -204,9 +204,9 @@ Also note that we use `fastlane/metadata/android/en-US/changelogs/default.txt` t
           path: build/WebGL
       - name: Copy the WebGL build artifacts to the GitHub Pages directory
         env:
-          WEBGL_BUILD_PATH: ${{ format('{0}/build/WebGL', github.workspace) }}
-          WEBGL_PAGES_PATH: ${{ format('{0}/docs/WebGL', github.workspace) }}
-        run: find $WEBGL_BUILD_PATH -type f -name "**WebGL.*" -exec cp {} $WEBGL_PAGES_PATH \;
+          WEBGL_BUILD_PATH: ${{ format('{0}/build/WebGL/WebGL/.', github.workspace) }}
+          WEBGL_PAGES_PATH: ${{ format('{0}/docs', github.workspace) }}
+        run: cp -r $WEBGL_BUILD_PATH $WEBGL_PAGES_PATH;
       - name: Deploy to GitHub Pages
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/gameci-3_linux.md
+++ b/gameci-3_linux.md
@@ -196,9 +196,9 @@ Also note that we use `fastlane/metadata/android/en-US/changelogs/default.txt` t
     if: github.event.action == 'published' || (contains(github.event.inputs.workflow_mode, 'release') && contains(github.event.inputs.workflow_mode, 'WebGL'))
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download WebGL Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cgs-WebGL
           path: build/WebGL


### PR DESCRIPTION
Found this webpage really useful in figuring this out, thanks. I did have to solve one issue which I've quickly updated here to help any others struggling with this. Updates here deploys the entire build, including TemplateData/ which includes useful image assets and the css file, and the index.html in the root dir.

Not tested on this version of the code, but my own version which does work can be seen here, with a slightly different setup, if useful: https://github.com/Sussex-Psychology-Software-Team/Doggo-Nogo/blob/main/.github/workflows/main.yaml. This is the resulting pages deployment: https://sussex-psychology-software-team.github.io/Doggo-Nogo/

Note that mine downloads the artefact to 'build' directly, whilst your own version actually saves the build to build/WebGL, which means the location of the build files might actually be nested one deeper in /build/WebGL/WebGL/WebGL/.

I also removed 'build' from the .gitignore - believe this is required here.

Cheers